### PR TITLE
Fix inline component in logout tab

### DIFF
--- a/cutesy-finance/components/Tabs.js
+++ b/cutesy-finance/components/Tabs.js
@@ -52,7 +52,6 @@ export default function Tabs({ onLogout }) {
       />
       <Tab.Screen
         name="Logout"
-        component={() => null}
         listeners={{ tabPress: (e) => { e.preventDefault(); onLogout(); } }}
         options={{
           headerShown: false,
@@ -60,7 +59,9 @@ export default function Tabs({ onLogout }) {
             <Ionicons name="log-out" color={color} size={size} />
           ),
         }}
-      />
+      >
+        {() => null}
+      </Tab.Screen>
     </Tab.Navigator>
   );
 }


### PR DESCRIPTION
## Summary
- refactor `Tabs.js` to avoid using an inline component for the logout screen

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_686bc6b922e08321aa1374f4ae48d12c