### PR TITLE
Fix Android DETECT_SCREEN_CAPTURE error

### DIFF
--- a/cutesy-finance/app.json
+++ b/cutesy-finance/app.json
@@ -23,7 +23,8 @@
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#FFFFFF"
-      }
+      },
+      "permissions": ["DETECT_SCREEN_CAPTURE"]
     },
     "web": {
       "favicon": "./assets/favicon.png"


### PR DESCRIPTION
## Summary
- specify `DETECT_SCREEN_CAPTURE` permission in Expo config

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686bcabfd51c832183fc9a45d11af956