### PR TITLE
Update login credentials and menu UI

### DIFF
--- a/cutesy-finance/components/DrawerMenu.js
+++ b/cutesy-finance/components/DrawerMenu.js
@@ -1,66 +1,39 @@
-// Slide-out drawer that appears from the left side of the screen.
-// Can be dragged closed or dismissed by tapping the backdrop.
-import React, { useRef } from 'react';
-import { View, Text, StyleSheet, Animated, Dimensions, TouchableOpacity, PanResponder } from 'react-native';
-
-const { width } = Dimensions.get('window');
+// Simple flyout menu displayed over the current screen.
+// No sliding drawer animation to keep it lightweight.
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
 
 export default function DrawerMenu({ visible, onClose, onLogout }) {
-  // Animated value controlling the drawer's X translation
-  const transX = useRef(new Animated.Value(-width)).current;
-
-  React.useEffect(() => {
-    Animated.timing(transX, {
-      toValue: visible ? 0 : -width,
-      duration: 300,
-      useNativeDriver: true,
-    }).start();
-  }, [visible]);
-
-  // Allow the user to drag the drawer closed
-  const panResponder = useRef(
-    PanResponder.create({
-      onMoveShouldSetPanResponder: (_, g) => g.dx > 10,
-      onPanResponderRelease: (_, g) => {
-        if (g.dx < -50) onClose();
-      },
-    })
-  ).current;
+  if (!visible) return null;
 
   return (
     <View style={StyleSheet.absoluteFill} pointerEvents="box-none">
-      {visible && <TouchableOpacity style={styles.backdrop} onPress={onClose} />}
-      <Animated.View
-        style={[styles.drawer, { transform: [{ translateX: transX }] }]}
-        pointerEvents={visible ? 'auto' : 'none'}
-        {...panResponder.panHandlers}
-      >
+      <TouchableOpacity style={styles.backdrop} onPress={onClose} />
+      <View style={styles.menu} pointerEvents="auto">
         {['Option A', 'Option B', 'Option C', 'Option D'].map((t) => (
           <Text key={t} style={styles.item}>{t}</Text>
         ))}
         <TouchableOpacity onPress={onLogout}>
           <Text style={[styles.item, styles.logout]}>Logout</Text>
         </TouchableOpacity>
-      </Animated.View>
+      </View>
     </View>
   );
 }
 
-// Styling for the drawer and its backdrop
+// Styling for the flyout menu and its backdrop
 const styles = StyleSheet.create({
   backdrop: {
     ...StyleSheet.absoluteFillObject,
     backgroundColor: 'rgba(0,0,0,0.3)',
   },
-  drawer: {
+  menu: {
     position: 'absolute',
-    left: 0,
-    top: 0,
-    bottom: 0,
-    width: width * 0.7,
+    top: 70,
+    left: 20,
     backgroundColor: '#957DAD',
-    paddingTop: 60,
-    paddingHorizontal: 20,
+    padding: 20,
+    borderRadius: 10,
   },
   item: {
     color: '#fff',

--- a/cutesy-finance/components/LoginModal.js
+++ b/cutesy-finance/components/LoginModal.js
@@ -4,18 +4,18 @@ import React, { useState } from 'react';
 import { View, Text, StyleSheet, TextInput, TouchableOpacity } from 'react-native';
 
 export default function LoginModal({ onClose, onSuccess }) {
-  const [email, setEmail] = useState('');
+  const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
 
   // Very basic credential check for demonstration.
   // In a real app you would make a request to your backend here.
   const handleLogin = () => {
-    if (email === 'a@b.com' && password === 'P@') {
+    if (username === 'a' && password === 'a') {
       setError('');
       onSuccess();
     } else {
-      setError('Incorrect email or password');
+      setError('Incorrect username or password');
     }
   };
 
@@ -25,11 +25,11 @@ export default function LoginModal({ onClose, onSuccess }) {
       <View style={styles.modal}>
         <Text style={styles.header}>Login</Text>
         <TextInput
-          placeholder="Email"
+          placeholder="Username"
           style={styles.input}
           autoCapitalize="none"
-          value={email}
-          onChangeText={setEmail}
+          value={username}
+          onChangeText={setUsername}
         />
         <TextInput
           placeholder="Password"

--- a/cutesy-finance/components/Tabs.js
+++ b/cutesy-finance/components/Tabs.js
@@ -16,8 +16,12 @@ export default function Tabs({ onLogout }) {
     <Tab.Navigator
       screenOptions={({ route }) => ({
         tabBarShowLabel: true,
+        tabBarLabelPosition: 'beside-icon',
+        tabBarItemStyle: { flexDirection: 'row' },
         tabBarLabel: ({ focused, color }) =>
-          focused ? <Text style={[styles.label, { color }]}>{route.name}</Text> : null,
+          focused ? (
+            <Text style={[styles.label, { color }]}>{route.name}</Text>
+          ) : null,
         tabBarActiveTintColor: '#957DAD',
         tabBarStyle: { height: 60 },
       })}
@@ -74,5 +78,6 @@ const styles = StyleSheet.create({
   label: {
     fontFamily: 'Poppins_400Regular',
     fontSize: 12,
+    marginLeft: 5,
   },
 });


### PR DESCRIPTION
## Summary
- simplify DrawerMenu into a basic flyout overlay
- accept username `a` and password `a` when logging in
- place selected tab labels beside their icons

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_b_686bdb5e81d483218bdabc2516398965