### PR TITLE
Add chat and uploads tabs

### DIFF
--- a/cutesy-finance/components/ChatScreen.js
+++ b/cutesy-finance/components/ChatScreen.js
@@ -1,0 +1,115 @@
+import React from 'react';
+import { View, Text, StyleSheet, ScrollView, Image } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+export default function ChatScreen() {
+  // Simple chat history with text, image, video thumbnail and audio entry
+  return (
+    <View style={styles.container}>
+      <ScrollView contentContainerStyle={styles.scroll}>
+        {/* Incoming text */}
+        <View style={[styles.message, styles.theirMessage]}>
+          <Text style={styles.text}>Hi! How are you?</Text>
+        </View>
+        {/* Outgoing text */}
+        <View style={[styles.message, styles.myMessage]}>
+          <Text style={styles.text}>Doing great! Check out this photo.</Text>
+        </View>
+        {/* Outgoing image */}
+        <View style={[styles.message, styles.myMessage]}>
+          <Image source={require('../assets/icon.png')} style={styles.image} />
+        </View>
+        {/* Incoming text */}
+        <View style={[styles.message, styles.theirMessage]}>
+          <Text style={styles.text}>Nice! Here is a short video.</Text>
+        </View>
+        {/* Incoming video thumbnail */}
+        <View style={[styles.message, styles.theirMessage]}>
+          <View style={styles.videoContainer}>
+            <Image source={require('../assets/splash.png')} style={styles.videoImg} />
+            <Ionicons name="play-circle" size={48} color="#fff" style={styles.playIcon} />
+          </View>
+        </View>
+        {/* Outgoing text introducing audio */}
+        <View style={[styles.message, styles.myMessage]}>
+          <Text style={styles.text}>Great! Listen to this voice memo.</Text>
+        </View>
+        {/* Outgoing audio placeholder */}
+        <View style={[styles.message, styles.myMessage]}>
+          <View style={styles.audioContainer}>
+            <Ionicons name="play" size={24} color="#fff" />
+            <View style={styles.waveform}>
+              {[4,8,12,8,4].map((h,i) => (
+                <View key={i} style={[styles.bar,{height:h*2}]} />
+              ))}
+            </View>
+          </View>
+        </View>
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+    paddingTop: 50,
+  },
+  scroll: {
+    paddingHorizontal: 10,
+    paddingBottom: 20,
+  },
+  message: {
+    maxWidth: '75%',
+    borderRadius: 10,
+    padding: 8,
+    marginVertical: 5,
+  },
+  theirMessage: {
+    alignSelf: 'flex-start',
+    backgroundColor: '#FEC8D8',
+  },
+  myMessage: {
+    alignSelf: 'flex-end',
+    backgroundColor: '#cebffa',
+  },
+  text: {
+    fontFamily: 'Poppins_400Regular',
+    fontSize: 14,
+  },
+  image: {
+    width: 160,
+    height: 120,
+    borderRadius: 8,
+  },
+  videoContainer: {
+    width: 160,
+    height: 120,
+    borderRadius: 8,
+    overflow: 'hidden',
+    position: 'relative',
+  },
+  videoImg: {
+    width: '100%',
+    height: '100%',
+  },
+  playIcon: {
+    position: 'absolute',
+    top: '40%',
+    left: '40%',
+  },
+  audioContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  waveform: {
+    flexDirection: 'row',
+    marginLeft: 8,
+  },
+  bar: {
+    width: 4,
+    backgroundColor: '#fff',
+    marginHorizontal: 1,
+  },
+});

--- a/cutesy-finance/components/Tabs.js
+++ b/cutesy-finance/components/Tabs.js
@@ -5,8 +5,8 @@ import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { Ionicons, FontAwesome5 } from '@expo/vector-icons';
 import { View, Text, StyleSheet } from 'react-native';
 import Dashboard from './Dashboard';
-import Menu2Screen from './Menu2Screen';
-import Menu3Screen from './Menu3Screen';
+import UploadsScreen from './UploadsScreen';
+import ChatScreen from './ChatScreen';
 
 const Tab = createBottomTabNavigator();
 
@@ -32,13 +32,13 @@ export default function Tabs({ onLogout }) {
               iconName = 'folder';
               IconComponent = Ionicons;
               break;
-            case 'Menu 2':
-              iconName = 'disc';
+            case 'Uploads':
+              iconName = 'arrow-up-circle';
               IconComponent = Ionicons;
               break;
-            case 'Menu 3':
-              iconName = 'check';
-              IconComponent = FontAwesome5;
+            case 'Chat':
+              iconName = 'chatbubbles';
+              IconComponent = Ionicons;
               break;
             case 'Logout':
               iconName = 'log-out';
@@ -67,8 +67,8 @@ export default function Tabs({ onLogout }) {
         {() => <Dashboard onLogout={onLogout} />}
       </Tab.Screen>
 
-      <Tab.Screen name="Menu 2" component={Menu2Screen} options={{ headerShown: false }} />
-      <Tab.Screen name="Menu 3" component={Menu3Screen} options={{ headerShown: false }} />
+      <Tab.Screen name="Uploads" component={UploadsScreen} options={{ headerShown: false }} />
+      <Tab.Screen name="Chat" component={ChatScreen} options={{ headerShown: false }} />
 
       <Tab.Screen
         name="Logout"

--- a/cutesy-finance/components/UploadsScreen.js
+++ b/cutesy-finance/components/UploadsScreen.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+export default function UploadsScreen() {
+  return (
+    <View style={styles.container}>
+      <View style={styles.list}>
+        <Text style={styles.item}>family_photo.jpg</Text>
+        <Text style={styles.item}>bank_statement.pdf</Text>
+        <Text style={styles.item}>tax_docs.pdf</Text>
+      </View>
+      <View style={styles.buttonRow}>
+        <TouchableOpacity style={styles.button}>
+          <Ionicons name="document" size={20} color="#fff" />
+          <Text style={styles.buttonText}>Upload PDF</Text>
+        </TouchableOpacity>
+        <TouchableOpacity style={styles.button}>
+          <Ionicons name="image" size={20} color="#fff" />
+          <Text style={styles.buttonText}>Upload Photo</Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    paddingTop: 50,
+    backgroundColor: '#FFDFD3',
+  },
+  list: {
+    width: '80%',
+    marginBottom: 20,
+  },
+  item: {
+    fontFamily: 'Poppins_400Regular',
+    fontSize: 16,
+    marginVertical: 4,
+  },
+  buttonRow: {
+    flexDirection: 'row',
+  },
+  button: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#cebffa',
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 8,
+    marginHorizontal: 5,
+  },
+  buttonText: {
+    marginLeft: 6,
+    color: '#fff',
+    fontFamily: 'Poppins_400Regular',
+    fontSize: 14,
+  },
+});


### PR DESCRIPTION
## Summary
- create `ChatScreen` showing text, image, video and audio placeholders
- create `UploadsScreen` with sample file list and upload buttons
- hook new screens into `Tabs` and update tab icons

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_686cca45411483219aeea64762d8ad62