### PR TITLE
Add chat service and integrate real chat

### DIFF
--- a/cutesy-finance/components/ChatScreen.js
+++ b/cutesy-finance/components/ChatScreen.js
@@ -1,34 +1,39 @@
-import React, { useState, useEffect, useRef, useMemo } from 'react';
-import { View, Text, StyleSheet, ScrollView, Image, TouchableOpacity, Animated } from 'react-native';
+import React, { useState, useEffect, useRef } from 'react';
+import { View, Text, StyleSheet, FlatList, Image, TouchableOpacity, Modal, Animated } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
+import { Video } from 'expo-av';
 import DrawerMenu from './DrawerMenu';
+import { getChatMessages } from '../services/ChatService';
 
 export default function ChatScreen({ onLogout }) {
   const [menuVisible, setMenuVisible] = useState(false);
+  const [messages, setMessages] = useState([]);
+  const [page, setPage] = useState(1);
+  const [more, setMore] = useState(true);
+  const [loading, setLoading] = useState(false);
+  const [videoUrl, setVideoUrl] = useState(null);
+  const [audioUrl, setAudioUrl] = useState(null);
   const drawerAnim = useRef(new Animated.Value(0)).current;
 
-  const backgroundIcons = useMemo(() => {
-    const icons = [];
-    for (let row = 0; row < 12; row++) {
-      for (let col = 0; col < 5; col++) {
-        icons.push(
-          <Ionicons
-            key={`${row}-${col}`}
-            name="chatbubble"
-            size={48}
-            color="#cebffa"
-            style={{
-              position: 'absolute',
-              top: row * 70,
-              left: col * 80,
-              opacity: 0.08,
-            }}
-          />
-        );
-      }
-    }
-    return icons;
+  useEffect(() => {
+    loadMessages(1);
   }, []);
+
+  const loadMessages = async (p) => {
+    if (loading || !more) return;
+    setLoading(true);
+    try {
+      const data = await getChatMessages(p);
+      const newMsgs = data && data.messages ? data.messages : [];
+      setMessages((prev) => (p === 1 ? newMsgs : [...prev, ...newMsgs]));
+      setMore(data ? data.moreMessagesAvailable : false);
+      setPage(p);
+    } catch (e) {
+      console.warn('Failed loading chat', e);
+    } finally {
+      setLoading(false);
+    }
+  };
 
   useEffect(() => {
     Animated.timing(drawerAnim, {
@@ -55,129 +60,114 @@ export default function ChatScreen({ onLogout }) {
     ],
   };
 
-  // Simple chat history with text, image, video thumbnail and audio entry
+  const renderMessage = ({ item, index }) => {
+    const previous = messages[index - 1];
+    const showDate = !previous || Math.abs(new Date(item.sentTime) - new Date(previous.sentTime)) > 30 * 60 * 1000;
+    const [showTime, setShowTime] = useState(false);
+    const messageText = item.hasEmbeddedUrl ? parseEmbeddedUrl(item.message) : item.message;
+
+    return (
+      <View>
+        {showDate && <Text style={styles.date}>{new Date(item.sentTime).toLocaleString()}</Text>}
+        <TouchableOpacity
+          onPress={() => setShowTime(!showTime)}
+          style={[styles.message, item.brokerSource ? styles.theirMessage : styles.myMessage]}
+        >
+          {item.image && (
+            <Image source={{ uri: `data:image/png;base64,${item.image}` }} style={styles.image} />
+          )}
+          {item.isVideo && item.videoUrl && (
+            <TouchableOpacity onPress={() => setVideoUrl(item.videoUrl)} style={styles.videoContainer}>
+              {item.image ? (
+                <Image source={{ uri: `data:image/png;base64,${item.image}` }} style={styles.videoImg} />
+              ) : (
+                <View style={[styles.videoImg, styles.videoPlaceholder]} />
+              )}
+              <Ionicons name="play-circle" size={48} color="#fff" style={styles.playIcon} />
+            </TouchableOpacity>
+          )}
+          {item.isAudio && item.audioUrl && (
+            <TouchableOpacity onPress={() => setAudioUrl(item.audioUrl)} style={styles.videoContainer}>
+              <Ionicons name="musical-notes" size={48} color="#fff" style={styles.playIcon} />
+            </TouchableOpacity>
+          )}
+          {typeof messageText === 'string' ? (
+            <Text style={styles.text}>{messageText}</Text>
+          ) : (
+            <Text style={styles.text}>{messageText.prefix}<Text style={styles.link} onPress={() => openUrl(messageText.url)}>{messageText.url}</Text>{messageText.suffix}</Text>
+          )}
+          {showTime && <Text style={styles.time}>{new Date(item.sentTime).toLocaleTimeString()}</Text>}
+        </TouchableOpacity>
+      </View>
+    );
+  };
+
+  const openUrl = async (url) => {
+    const WebBrowser = await import('expo-web-browser');
+    WebBrowser.openBrowserAsync(url);
+  };
+
+  const parseEmbeddedUrl = (msg) => {
+    const start = msg.indexOf('<--');
+    const end = msg.indexOf('-->');
+    if (start !== -1 && end !== -1 && end > start) {
+      return {
+        prefix: msg.substring(0, start),
+        url: msg.substring(start + 3, end).trim(),
+        suffix: msg.substring(end + 3),
+      };
+    }
+    return msg;
+  };
+
+  const handleEndReached = () => {
+    if (!loading && more) {
+      loadMessages(page + 1);
+    }
+  };
+
   return (
     <Animated.View style={[styles.container, animatedStyles]}>
-      <View style={styles.iconBackground} pointerEvents="none">
-        {backgroundIcons}
-      </View>
-      <TouchableOpacity
-        onPress={() => setMenuVisible(true)}
-        style={styles.burger}
-      >
+      <TouchableOpacity onPress={() => setMenuVisible(true)} style={styles.burger}>
         <Ionicons name="menu" size={32} color="#cebffa" />
       </TouchableOpacity>
       <Text style={styles.header}>Chats</Text>
-      <ScrollView contentContainerStyle={styles.scroll}>
-        {/* Incoming text */}
-        <View style={[styles.message, styles.theirMessage]}>
-          <Text style={styles.text}>Hi! How are you?</Text>
-        </View>
-        {/* Outgoing text */}
-        <View style={[styles.message, styles.myMessage]}>
-          <Text style={styles.text}>Doing great! Check out this photo.</Text>
-        </View>
-        {/* Outgoing image */}
-        <View style={[styles.message, styles.myMessage]}>
-          <Image source={require('../assets/fake-image.png')} style={styles.image} />
-        </View>
-        {/* Incoming text */}
-        <View style={[styles.message, styles.theirMessage]}>
-          <Text style={styles.text}>Nice! Here is a short video.</Text>
-        </View>
-        {/* Incoming video thumbnail */}
-        <View style={[styles.message, styles.theirMessage]}>
-          <View style={styles.videoContainer}>
-            <Image source={require('../assets/fake-video.png')} style={styles.videoImg} />
-            <Ionicons name="play-circle" size={48} color="#fff" style={styles.playIcon} />
-          </View>
-        </View>
-        {/* Outgoing text introducing audio */}
-        <View style={[styles.message, styles.myMessage]}>
-          <Text style={styles.text}>Great! Listen to this voice memo.</Text>
-        </View>
-        {/* Outgoing audio placeholder */}
-        <View style={[styles.message, styles.myMessage]}>
-          <View style={styles.audioContainer}>
-            <Ionicons name="play" size={24} color="#fff" />
-            <View style={styles.waveform}>
-              {[4, 8, 12, 8, 4].map((h, i) => (
-                <View key={i} style={[styles.bar, { height: h * 2 }]} />
-              ))}
-            </View>
-          </View>
-        </View>
-        {/* Repeat messages to enable scrolling */}
-        {/* 2nd set */}
-        <View style={[styles.message, styles.theirMessage]}>
-          <Text style={styles.text}>Hi! How are you?</Text>
-        </View>
-        <View style={[styles.message, styles.myMessage]}>
-          <Text style={styles.text}>Doing great! Check out this photo.</Text>
-        </View>
-        <View style={[styles.message, styles.myMessage]}>
-          <Image source={require('../assets/fake-image.png')} style={styles.image} />
-        </View>
-        <View style={[styles.message, styles.theirMessage]}>
-          <Text style={styles.text}>Nice! Here is a short video.</Text>
-        </View>
-        <View style={[styles.message, styles.theirMessage]}>
-          <View style={styles.videoContainer}>
-            <Image source={require('../assets/fake-video.png')} style={styles.videoImg} />
-            <Ionicons name="play-circle" size={48} color="#fff" style={styles.playIcon} />
-          </View>
-        </View>
-        <View style={[styles.message, styles.myMessage]}>
-          <Text style={styles.text}>Great! Listen to this voice memo.</Text>
-        </View>
-        <View style={[styles.message, styles.myMessage]}>
-          <View style={styles.audioContainer}>
-            <Ionicons name="play" size={24} color="#fff" />
-            <View style={styles.waveform}>
-              {[4, 8, 12, 8, 4].map((h, i) => (
-                <View key={i} style={[styles.bar, { height: h * 2 }]} />
-              ))}
-            </View>
-          </View>
-        </View>
-        {/* 3rd set */}
-        <View style={[styles.message, styles.theirMessage]}>
-          <Text style={styles.text}>Hi! How are you?</Text>
-        </View>
-        <View style={[styles.message, styles.myMessage]}>
-          <Text style={styles.text}>Doing great! Check out this photo.</Text>
-        </View>
-        <View style={[styles.message, styles.myMessage]}>
-          <Image source={require('../assets/fake-image.png')} style={styles.image} />
-        </View>
-        <View style={[styles.message, styles.theirMessage]}>
-          <Text style={styles.text}>Nice! Here is a short video.</Text>
-        </View>
-        <View style={[styles.message, styles.theirMessage]}>
-          <View style={styles.videoContainer}>
-            <Image source={require('../assets/fake-video.png')} style={styles.videoImg} />
-            <Ionicons name="play-circle" size={48} color="#fff" style={styles.playIcon} />
-          </View>
-        </View>
-        <View style={[styles.message, styles.myMessage]}>
-          <Text style={styles.text}>Great! Listen to this voice memo.</Text>
-        </View>
-        <View style={[styles.message, styles.myMessage]}>
-          <View style={styles.audioContainer}>
-            <Ionicons name="play" size={24} color="#fff" />
-            <View style={styles.waveform}>
-              {[4, 8, 12, 8, 4].map((h, i) => (
-                <View key={i} style={[styles.bar, { height: h * 2 }]} />
-              ))}
-            </View>
-          </View>
-        </View>
-      </ScrollView>
-      <DrawerMenu
-        visible={menuVisible}
-        onClose={() => setMenuVisible(false)}
-        onLogout={onLogout}
+      <FlatList
+        data={messages}
+        keyExtractor={(item) => item.id.toString()}
+        renderItem={renderMessage}
+        contentContainerStyle={styles.scroll}
+        onEndReachedThreshold={0.2}
+        onEndReached={handleEndReached}
       />
+      <DrawerMenu visible={menuVisible} onClose={() => setMenuVisible(false)} onLogout={onLogout} />
+      <Modal visible={!!videoUrl} transparent onRequestClose={() => setVideoUrl(null)}>
+        <View style={styles.modalBg}>
+          <TouchableOpacity style={styles.close} onPress={() => setVideoUrl(null)}>
+            <Ionicons name="close" size={32} color="#fff" />
+          </TouchableOpacity>
+          {videoUrl && <Video source={{ uri: videoUrl }} style={styles.media} useNativeControls resizeMode="contain" />}
+        </View>
+      </Modal>
+      <Modal visible={!!audioUrl} transparent onRequestClose={() => setAudioUrl(null)}>
+        <View style={styles.modalBg}>
+          <TouchableOpacity style={styles.close} onPress={() => setAudioUrl(null)}>
+            <Ionicons name="close" size={32} color="#fff" />
+          </TouchableOpacity>
+          {audioUrl && (
+            <Video
+              source={{ uri: audioUrl }}
+              useNativeControls
+              resizeMode="contain"
+              style={styles.media}
+              shouldPlay
+              onPlaybackStatusUpdate={(status) => {
+                if (status.didJustFinish) setAudioUrl(null);
+              }}
+            />
+          )}
+        </View>
+      </Modal>
     </Animated.View>
   );
 }
@@ -187,9 +177,6 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: '#fff',
     paddingTop: 50,
-  },
-  iconBackground: {
-    ...StyleSheet.absoluteFillObject,
   },
   burger: {
     position: 'absolute',
@@ -239,6 +226,7 @@ const styles = StyleSheet.create({
     borderRadius: 8,
     overflow: 'hidden',
     position: 'relative',
+    marginBottom: 5,
   },
   videoImg: {
     width: '100%',
@@ -249,17 +237,38 @@ const styles = StyleSheet.create({
     top: '40%',
     left: '40%',
   },
-  audioContainer: {
-    flexDirection: 'row',
+  videoPlaceholder: {
+    backgroundColor: '#ccc',
+  },
+  time: {
+    fontSize: 10,
+    color: '#555',
+    alignSelf: 'flex-end',
+  },
+  date: {
+    alignSelf: 'center',
+    fontSize: 12,
+    marginVertical: 10,
+    color: '#888',
+  },
+  modalBg: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.8)',
+    justifyContent: 'center',
     alignItems: 'center',
   },
-  waveform: {
-    flexDirection: 'row',
-    marginLeft: 8,
+  close: {
+    position: 'absolute',
+    top: 40,
+    right: 20,
+    zIndex: 1,
   },
-  bar: {
-    width: 4,
-    backgroundColor: '#fff',
-    marginHorizontal: 1,
+  media: {
+    width: '90%',
+    height: '70%',
+  },
+  link: {
+    textDecorationLine: 'underline',
+    color: 'blue',
   },
 });

--- a/cutesy-finance/package.json
+++ b/cutesy-finance/package.json
@@ -21,7 +21,8 @@
     "react-native-safe-area-context": "4.8.2",
     "@expo/vector-icons": "^14.0.0",
     "expo-font": "^11.4.0",
-    "@expo-google-fonts/poppins": "^0.3.0"
-    ,"expo-secure-store": "^12.4.0"
+    "@expo-google-fonts/poppins": "^0.3.0",
+    "expo-secure-store": "^12.4.0",
+    "expo-av": "~13.2.1"
   }
 }

--- a/cutesy-finance/services/ChatService.js
+++ b/cutesy-finance/services/ChatService.js
@@ -1,0 +1,44 @@
+import { getBaseUrl, getToken } from './LoginService';
+import * as SecureStore from 'expo-secure-store';
+
+const CHAT_PATH = 'Chat/GetChat';
+const PAGE_SIZE = 15;
+
+export const getChatMessages = async (pageNumber = 1) => {
+  const baseUrl = getBaseUrl();
+  const token = getToken();
+  const userId = await SecureStore.getItemAsync('userId');
+  const masterBrokerId = await SecureStore.getItemAsync('masterBrokerId');
+
+  if (!baseUrl || !token || !userId || !masterBrokerId) {
+    throw new Error('Missing chat configuration');
+  }
+
+  const payload = {
+    CustomerId: parseInt(userId, 10),
+    BrokerId: parseInt(masterBrokerId, 10),
+    MarkAsRead: false,
+    GetDocumentFileContents: false,
+    GetImageDocumentFileContents: false,
+    CachedImageGuids: [],
+    GetLatestMessagesByCount: 0,
+    PageNumber: pageNumber,
+    PageSize: PAGE_SIZE,
+  };
+
+  const response = await fetch(`${baseUrl.replace(/\/+$/, '')}/${CHAT_PATH}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to load chat messages');
+  }
+
+  const data = await response.json();
+  return data;
+};

--- a/cutesy-finance/services/LoginService.js
+++ b/cutesy-finance/services/LoginService.js
@@ -1,3 +1,5 @@
+import * as SecureStore from 'expo-secure-store';
+
 const LOGIN_PATH = 'Auth/SignIn';
 
 let baseUrl = '';
@@ -24,8 +26,17 @@ export const login = async (emailAddress, password) => {
   });
 
   const data = await response.json();
-  if (data && data.token) {
-    token = data.token;
+  if (data && (data.token || data.Token)) {
+    token = data.token || data.Token;
+    await SecureStore.setItemAsync('authToken', token);
+  }
+  const uid = data.userId ?? data.UserId;
+  if (uid !== undefined) {
+    await SecureStore.setItemAsync('userId', String(uid));
+  }
+  const mbid = data.masterBrokerId ?? data.MasterBrokerId;
+  if (mbid !== undefined) {
+    await SecureStore.setItemAsync('masterBrokerId', String(mbid));
   }
   return data;
 };


### PR DESCRIPTION
## Summary
- add masterBrokerId and userId storage in login service
- create ChatService to load messages
- display messages from service in ChatScreen
- support images, video and audio playback and embedded links
- add expo-av dependency
- handle mixed casing in login response fields

## Testing
- `npm -v`


------
https://chatgpt.com/codex/tasks/task_b_686eb046d00883219e6bae06cb3674ae