### PR TITLE
Add appsettings config for base URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ cutesy-finance/node_modules/
 # Mac and Expo files
 .DS_Store
 .expo/
+
+cutesy-finance/appsettings.json

--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ This is a small demo banking app built with Expo/React Native. It includes iOS a
 
 1. Install [Node.js](https://nodejs.org/) and [Expo CLI](https://docs.expo.dev/get-started/installation/).
 2. Run `npm install` in the `cutesy-finance` directory.
-3. Start the development server with `npm start` (or `expo start`).
-4. Use the iOS Simulator, Android emulator or a physical device to run the app.
+3. Copy `appsettings.example.json` to `appsettings.json` in the `cutesy-finance` directory and edit the `baseUrl` value.
+4. Start the development server with `npm start` (or `expo start`).
+5. Use the iOS Simulator, Android emulator or a physical device to run the app.
 
 This demo uses only the built-in React Native `Animated` API. The
 `react-native-reanimated` package was removed to avoid native initialization

--- a/cutesy-finance/App.js
+++ b/cutesy-finance/App.js
@@ -15,6 +15,7 @@ import WelcomeScreen from './components/WelcomeScreen';
 import RegisterScreen from './components/RegisterScreen';
 import Tabs from './components/Tabs';
 import { setBaseUrl } from './services/LoginService';
+import appSettings from './appsettings.json';
 
 const Stack = createNativeStackNavigator();
 
@@ -25,7 +26,7 @@ export default function App() {
   const [fontsLoaded] = useFonts({ Poppins_400Regular });
 
   useEffect(() => {
-    setBaseUrl('http://example.com');
+    setBaseUrl(appSettings.baseUrl);
   }, []);
 
   // Show a loader until fonts are ready

--- a/cutesy-finance/appsettings.example.json
+++ b/cutesy-finance/appsettings.example.json
@@ -1,0 +1,3 @@
+{
+  "baseUrl": "http://example.com"
+}


### PR DESCRIPTION
## Summary
- load API URL from `appsettings.json`
- ignore `appsettings.json` in git and provide an example file
- update setup instructions

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_686eb28f71f0832183689d89bc243b81