### PR TITLE
Fix chat list orientation and media display

### DIFF
--- a/cutesy-finance/components/ChatMessage.js
+++ b/cutesy-finance/components/ChatMessage.js
@@ -1,6 +1,15 @@
 import React, { useState } from 'react';
 import { View, Text, TouchableOpacity, Image } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
+import { Swipeable } from 'react-native-gesture-handler';
+
+const WaveformIcon = () => (
+  <View style={styles.waveformIcon}>
+    {[4, 7, 5, 6, 4].map((h, i) => (
+      <View key={i} style={[styles.waveBar, { height: h * 2 }]} />
+    ))}
+  </View>
+);
 
 export default function ChatMessage({ item, previous, styles, setVideoUrl, setAudioUrl, openUrl }) {
   const [showTime, setShowTime] = useState(false);
@@ -25,43 +34,49 @@ export default function ChatMessage({ item, previous, styles, setVideoUrl, setAu
   return (
     <View>
       {showDate && <Text style={styles.date}>{new Date(item.sentTime).toLocaleString()}</Text>}
-      <TouchableOpacity
-        onPress={() => setShowTime(!showTime)}
-        style={[styles.message, item.brokerSource ? styles.theirMessage : styles.myMessage]}
+      <Swipeable
+        renderLeftActions={() => <View />}
+        renderRightActions={() => <View />}
+        onSwipeableOpen={() => setShowTime(true)}
+        onSwipeableClose={() => setShowTime(false)}
       >
-        {item.image && (
-          <Image source={{ uri: `data:image/png;base64,${item.image}` }} style={styles.image} />
-        )}
-        {item.isVideo && item.videoUrl && (
-          <TouchableOpacity onPress={() => setVideoUrl(item.videoUrl)} style={styles.videoContainer}>
-            {item.image ? (
-              <Image source={{ uri: `data:image/png;base64,${item.image}` }} style={styles.videoImg} />
-            ) : (
-              <View style={[styles.videoImg, styles.videoPlaceholder]} />
-            )}
-            <Ionicons name="play-circle" size={48} color="#fff" style={styles.playIcon} />
-          </TouchableOpacity>
-        )}
-        {item.isAudio && item.audioUrl && (
-          <TouchableOpacity onPress={() => setAudioUrl(item.audioUrl)} style={styles.videoContainer}>
-            <Ionicons name="musical-notes" size={48} color="#fff" style={styles.playIcon} />
-          </TouchableOpacity>
-        )}
-        {typeof messageText === 'string' ? (
-          <Text style={styles.text}>{messageText}</Text>
-        ) : (
-          <Text style={styles.text}>
-            {messageText.prefix}
-            <Text style={styles.link} onPress={() => openUrl(messageText.url)}>
-              {messageText.url}
+        <TouchableOpacity
+          activeOpacity={0.8}
+          style={[styles.message, item.brokerSource ? styles.theirMessage : styles.myMessage]}
+        >
+          {item.isVideo && item.videoUrl ? (
+            <TouchableOpacity onPress={() => setVideoUrl(item.videoUrl)} style={styles.videoContainer}>
+              {item.image ? (
+                <Image source={{ uri: `data:image/png;base64,${item.image}` }} style={styles.videoImg} />
+              ) : (
+                <View style={[styles.videoImg, styles.videoPlaceholder]} />
+              )}
+              <Ionicons name="play-circle" size={48} color="#fff" style={styles.playIcon} />
+            </TouchableOpacity>
+          ) : (
+            item.image && <Image source={{ uri: `data:image/png;base64,${item.image}` }} style={styles.image} />
+          )}
+          {item.isAudio && item.audioUrl && (
+            <TouchableOpacity onPress={() => setAudioUrl(item.audioUrl)} style={styles.videoContainer}>
+              <WaveformIcon />
+            </TouchableOpacity>
+          )}
+          {typeof messageText === 'string' ? (
+            <Text style={styles.text}>{messageText}</Text>
+          ) : (
+            <Text style={styles.text}>
+              {messageText.prefix}
+              <Text style={styles.link} onPress={() => openUrl(messageText.url)}>
+                {messageText.url}
+              </Text>
+              {messageText.suffix}
             </Text>
-            {messageText.suffix}
-          </Text>
-        )}
-        {showTime && (
-          <Text style={styles.time}>{new Date(item.sentTime).toLocaleTimeString()}</Text>
-        )}
-      </TouchableOpacity>
+          )}
+          {showTime && (
+            <Text style={styles.time}>{new Date(item.sentTime).toLocaleTimeString()}</Text>
+          )}
+        </TouchableOpacity>
+      </Swipeable>
     </View>
   );
 }

--- a/cutesy-finance/components/ChatScreen.js
+++ b/cutesy-finance/components/ChatScreen.js
@@ -95,6 +95,8 @@ export default function ChatScreen({ onLogout }) {
         keyExtractor={(item) => item.id.toString()}
         renderItem={renderMessage}
         contentContainerStyle={styles.scroll}
+        inverted
+        initialNumToRender={15}
         onEndReachedThreshold={0.2}
         onEndReached={handleEndReached}
       />
@@ -154,6 +156,8 @@ const styles = StyleSheet.create({
   scroll: {
     paddingHorizontal: 10,
     paddingBottom: 20,
+    flexGrow: 1,
+    justifyContent: 'flex-end',
   },
   message: {
     maxWidth: '75%',
@@ -228,5 +232,17 @@ const styles = StyleSheet.create({
   link: {
     textDecorationLine: 'underline',
     color: 'blue',
+  },
+  waveformIcon: {
+    flexDirection: 'row',
+    alignItems: 'flex-end',
+    justifyContent: 'center',
+    width: '100%',
+    height: 30,
+  },
+  waveBar: {
+    width: 4,
+    backgroundColor: '#fff',
+    marginHorizontal: 2,
   },
 });


### PR DESCRIPTION
## Summary
- invert chat list so newest messages appear at the bottom
- show waveform icon for audio messages
- avoid duplicate image on video messages
- support swiping messages to reveal timestamp

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_686ec892b2a08321bb6f359582ba17d6