### PR TITLE
Add theme with reusable button

### DIFF
--- a/cutesy-finance/components/LoginModal.js
+++ b/cutesy-finance/components/LoginModal.js
@@ -2,6 +2,7 @@
 // Accepts only a preset username/password for demo purposes.
 import React, { useState, useRef, useEffect } from 'react';
 import { View, Text, StyleSheet, TextInput, TouchableOpacity, Alert } from 'react-native';
+import { PrimaryButton } from './Theme';
 import { Ionicons } from '@expo/vector-icons';
 import * as SecureStore from 'expo-secure-store';
 import { login as loginRequest } from '../services/LoginService';
@@ -91,9 +92,7 @@ export default function LoginModal({ onClose, onSuccess }) {
           </TouchableOpacity>
         </View>
         {error ? <Text style={styles.error}>{error}</Text> : null}
-        <TouchableOpacity style={styles.button} onPress={handleLogin}>
-          <Text style={styles.buttonText}>Login</Text>
-        </TouchableOpacity>
+        <PrimaryButton onPress={handleLogin}>Login</PrimaryButton>
         <TouchableOpacity onPress={onClose} style={styles.closeButton}>
           <Text style={styles.closeText}>Close</Text>
         </TouchableOpacity>
@@ -139,17 +138,6 @@ const styles = StyleSheet.create({
   error: {
     color: 'red',
     marginVertical: 5,
-  },
-  button: {
-    backgroundColor: '#cebffa',
-    padding: 12,
-    borderRadius: 5,
-    alignItems: 'center',
-    marginVertical: 10,
-  },
-  buttonText: {
-    color: '#fff',
-    fontFamily: 'Poppins_400Regular',
   },
   closeButton: {
     alignItems: 'center',

--- a/cutesy-finance/components/RegisterScreen.js
+++ b/cutesy-finance/components/RegisterScreen.js
@@ -1,7 +1,8 @@
 // Registration form allowing the user to sign up.
 // Includes a simple password strength meter for education.
 import React, { useState, useRef } from 'react';
-import { View, Text, StyleSheet, TextInput, TouchableOpacity } from 'react-native';
+import { View, Text, StyleSheet, TextInput } from 'react-native';
+import { PrimaryButton } from './Theme';
 
 export default function RegisterScreen() {
   const [email, setEmail] = useState('');
@@ -51,9 +52,9 @@ export default function RegisterScreen() {
       {strength ? (
         <Text style={[styles.strength, { color: colorMap[strength] }]}>Password strength: {strength}</Text>
       ) : null}
-      <TouchableOpacity style={styles.button} onPress={() => { }}>
-        <Text style={styles.buttonText}>Register</Text>
-      </TouchableOpacity>
+      <PrimaryButton onPress={() => { }}>
+        Register
+      </PrimaryButton>
     </View>
   );
 }
@@ -79,16 +80,5 @@ const styles = StyleSheet.create({
   },
   strength: {
     marginVertical: 5,
-  },
-  button: {
-    backgroundColor: '#cebffa',
-    padding: 12,
-    borderRadius: 5,
-    alignItems: 'center',
-    marginTop: 10,
-  },
-  buttonText: {
-    color: '#fff',
-    fontFamily: 'Poppins_400Regular',
   },
 });

--- a/cutesy-finance/components/Theme.js
+++ b/cutesy-finance/components/Theme.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import { StyleSheet, TouchableOpacity, Text } from 'react-native';
+
+export const COLORS = {
+  primary: '#cebffa',
+  secondary: '#FEC8D8',
+  tertiary: '#FFDFD3',
+  white: '#fff',
+  textDark: '#555',
+};
+
+export const SIZES = {
+  radius: 8,
+  padding: 12,
+};
+
+export function PrimaryButton({ children, style, textStyle, ...props }) {
+  return (
+    <TouchableOpacity style={[styles.primaryButton, style]} {...props}>
+      {typeof children === 'string' ? (
+        <Text style={[styles.primaryText, textStyle]}>{children}</Text>
+      ) : (
+        children
+      )}
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  primaryButton: {
+    backgroundColor: COLORS.primary,
+    paddingVertical: SIZES.padding,
+    paddingHorizontal: SIZES.padding * 1.5,
+    borderRadius: SIZES.radius,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  primaryText: {
+    color: COLORS.white,
+    fontFamily: 'Poppins_400Regular',
+    fontSize: 16,
+  },
+});

--- a/cutesy-finance/components/UploadsScreen.js
+++ b/cutesy-finance/components/UploadsScreen.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, Animated } from 'react-native';
+import { PrimaryButton } from './Theme';
 import { Ionicons } from '@expo/vector-icons';
 import DrawerMenu from './DrawerMenu';
 
@@ -57,14 +58,14 @@ export default function UploadsScreen({ onLogout }) {
         ))}
       </View>
       <View style={styles.buttonRow}>
-        <TouchableOpacity style={styles.button}>
+        <PrimaryButton style={styles.button}>
           <Ionicons name="document" size={20} color="#fff" />
           <Text style={styles.buttonText}>Upload PDF</Text>
-        </TouchableOpacity>
-        <TouchableOpacity style={styles.button}>
+        </PrimaryButton>
+        <PrimaryButton style={styles.button}>
           <Ionicons name="image" size={20} color="#fff" />
           <Text style={styles.buttonText}>Upload Photo</Text>
-        </TouchableOpacity>
+        </PrimaryButton>
       </View>
       <DrawerMenu
         visible={menuVisible}
@@ -127,12 +128,6 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
   },
   button: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    backgroundColor: '#cebffa',
-    paddingHorizontal: 12,
-    paddingVertical: 8,
-    borderRadius: 8,
     marginHorizontal: 5,
   },
   buttonText: {


### PR DESCRIPTION
## Summary
- add `components/Theme.js` providing color constants and `PrimaryButton`
- switch RegisterScreen, LoginModal and UploadsScreen to use the new button

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_686f74c6ddc0832180482e34705109f3