### PR TITLE
Update doc type lookup in ChatMessage

### DIFF
--- a/cutesy-finance/components/ChatMessage.js
+++ b/cutesy-finance/components/ChatMessage.js
@@ -36,7 +36,7 @@ export default function ChatMessage({ item, previous, styles, setVideoUrl, setAu
       ? parseEmbeddedUrl(item.message)
       : item.message;
 
-  const docType = parseInt(item.supportingDocumentType, 10);
+  const docType = parseInt(item.chatDocument?.supportingDocumentType, 10);
 
   let docLabel = null;
   if (item.chatDocumentId && item.chatDocumentId > 0 && !isNaN(docType)) {


### PR DESCRIPTION
## Summary
- use supportingDocumentType from nested chatDocument when rendering ChatMessage

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_686f82cf65d88321aa17d7c45c8f0d87