### PR TITLE
Enable image and pdf preview in chat

### DIFF
--- a/cutesy-finance/components/ChatMessage.js
+++ b/cutesy-finance/components/ChatMessage.js
@@ -12,7 +12,7 @@ const WaveformIcon = ({ styles }) => (
   </View>
 );
 
-export default function ChatMessage({ item, previous, styles, setVideoUrl, setAudioUrl, openUrl }) {
+export default function ChatMessage({ item, previous, styles, setVideoUrl, setAudioUrl, setImageUri, openPdf, openUrl }) {
   const [showTime, setShowTime] = useState(false);
 
   const showDate = !previous || Math.abs(new Date(item.sentTime) - new Date(previous.sentTime)) > 30 * 60 * 1000;
@@ -42,20 +42,22 @@ export default function ChatMessage({ item, previous, styles, setVideoUrl, setAu
   if (item.chatDocumentId && item.chatDocumentId > 0 && !isNaN(docType)) {
     if (docType === 1) {
       attachment = (
-        <Ionicons
-          name="document"
-          size={48}
-          color="#555"
-          style={styles.docIcon}
-        />
+        <TouchableOpacity onPress={() => openPdf(item.chatDocument?.File)}>
+          <Ionicons
+            name="document"
+            size={48}
+            color="#555"
+            style={styles.docIcon}
+          />
+        </TouchableOpacity>
       );
     } else if (docType === 2 || docType === 3) {
       const type = docType === 2 ? 'png' : 'jpeg';
+      const uri = `data:image/${type};base64,${item.chatDocument?.File}`;
       attachment = (
-        <Image
-          source={{ uri: `data:image/${type};base64,${item.chatDocument?.File}` }}
-          style={styles.image}
-        />
+        <TouchableOpacity onPress={() => setImageUri(uri)}>
+          <Image source={{ uri }} style={styles.image} />
+        </TouchableOpacity>
       );
     }
   }
@@ -83,7 +85,11 @@ export default function ChatMessage({ item, previous, styles, setVideoUrl, setAu
               <Ionicons name="play-circle" size={48} color="#fff" style={styles.playIcon} />
             </TouchableOpacity>
           ) : (
-            item.image && <Image source={{ uri: `data:image/png;base64,${item.image}` }} style={styles.image} />
+            item.image && (
+              <TouchableOpacity onPress={() => setImageUri(`data:image/png;base64,${item.image}`)}>
+                <Image source={{ uri: `data:image/png;base64,${item.image}` }} style={styles.image} />
+              </TouchableOpacity>
+            )
           )}
           {item.isAudio && item.audioUrl && (
             <TouchableOpacity onPress={() => setAudioUrl(item.audioUrl)} style={styles.videoContainer}>

--- a/cutesy-finance/components/ChatScreen.js
+++ b/cutesy-finance/components/ChatScreen.js
@@ -14,6 +14,7 @@ export default function ChatScreen({ onLogout }) {
   const [loading, setLoading] = useState(false);
   const [videoUrl, setVideoUrl] = useState(null);
   const [audioUrl, setAudioUrl] = useState(null);
+  const [imageUri, setImageUri] = useState(null);
   const drawerAnim = useRef(new Animated.Value(0)).current;
 
   useEffect(() => {
@@ -68,6 +69,8 @@ export default function ChatScreen({ onLogout }) {
       styles={styles}
       setVideoUrl={setVideoUrl}
       setAudioUrl={setAudioUrl}
+      setImageUri={setImageUri}
+      openPdf={openPdf}
       openUrl={openUrl}
     />
   );
@@ -75,6 +78,12 @@ export default function ChatScreen({ onLogout }) {
   const openUrl = async (url) => {
     const WebBrowser = await import('expo-web-browser');
     WebBrowser.openBrowserAsync(url);
+  };
+
+  const openPdf = async (base64) => {
+    if (!base64) return;
+    const WebBrowser = await import('expo-web-browser');
+    WebBrowser.openBrowserAsync(`data:application/pdf;base64,${base64}`);
   };
 
 
@@ -125,6 +134,16 @@ export default function ChatScreen({ onLogout }) {
                 if (status.didJustFinish) setAudioUrl(null);
               }}
             />
+          )}
+        </View>
+      </Modal>
+      <Modal visible={!!imageUri} transparent onRequestClose={() => setImageUri(null)}>
+        <View style={styles.modalBg}>
+          <TouchableOpacity style={styles.close} onPress={() => setImageUri(null)}>
+            <Ionicons name="close" size={32} color="#fff" />
+          </TouchableOpacity>
+          {imageUri && (
+            <Image source={{ uri: imageUri }} style={styles.media} resizeMode="contain" />
           )}
         </View>
       </Modal>


### PR DESCRIPTION
## Summary
- allow viewing attachments in chat
- show full-screen images in chat

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_686f88e9cf708321b9e0353a8373a61a