### PR TITLE
Fix thumbnails and add PDF fetch

### DIFF
--- a/cutesy-finance/components/ChatMessage.js
+++ b/cutesy-finance/components/ChatMessage.js
@@ -42,7 +42,7 @@ export default function ChatMessage({ item, previous, styles, setVideoUrl, setAu
   if (item.chatDocumentId && item.chatDocumentId > 0 && !isNaN(docType)) {
     if (docType === 1) {
       attachment = (
-        <TouchableOpacity onPress={() => openPdf(item.chatDocument?.File)}>
+        <TouchableOpacity onPress={() => openPdf(item.chatDocumentId, item.chatDocument?.File)}>
           <Ionicons
             name="document"
             size={48}

--- a/cutesy-finance/components/ChatScreen.js
+++ b/cutesy-finance/components/ChatScreen.js
@@ -4,7 +4,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { Video } from 'expo-av';
 import DrawerMenu from './DrawerMenu';
 import ChatMessage from './ChatMessage';
-import { getChatMessages } from '../services/ChatService';
+import { getChatMessages, getChatDocument } from '../services/ChatService';
 
 export default function ChatScreen({ onLogout }) {
   const [menuVisible, setMenuVisible] = useState(false);
@@ -80,10 +80,20 @@ export default function ChatScreen({ onLogout }) {
     WebBrowser.openBrowserAsync(url);
   };
 
-  const openPdf = async (base64) => {
-    if (!base64) return;
+  const openPdf = async (docId, base64) => {
+    let data = base64;
+    if (!data && docId) {
+      try {
+        const doc = await getChatDocument(docId);
+        data = doc.File || doc.file;
+      } catch (e) {
+        console.warn('Failed to load document', e);
+      }
+    }
+
+    if (!data) return;
     const WebBrowser = await import('expo-web-browser');
-    WebBrowser.openBrowserAsync(`data:application/pdf;base64,${base64}`);
+    WebBrowser.openBrowserAsync(`data:application/pdf;base64,${data}`);
   };
 
 

--- a/cutesy-finance/services/ChatService.js
+++ b/cutesy-finance/services/ChatService.js
@@ -2,6 +2,7 @@ import { getBaseUrl, getToken } from './LoginService';
 import * as SecureStore from 'expo-secure-store';
 
 const CHAT_PATH = 'Chat/pagedchat';
+const DOCUMENT_PATH = 'Document';
 const PAGE_SIZE = 15;
 
 export const getChatMessages = async (pageNumber = 1) => {
@@ -19,7 +20,8 @@ export const getChatMessages = async (pageNumber = 1) => {
     BrokerId: parseInt(masterBrokerId, 10),
     MarkAsRead: false,
     GetDocumentFileContents: false,
-    GetImageDocumentFileContents: false,
+    // Load image binary data so thumbnails display correctly
+    GetImageDocumentFileContents: true,
     CachedImageGuids: [],
     GetLatestMessagesByCount: 0,
     PageNumber: pageNumber,
@@ -41,4 +43,27 @@ export const getChatMessages = async (pageNumber = 1) => {
 
   const data = await response.json();
   return data;
+};
+
+export const getChatDocument = async (docId) => {
+  const baseUrl = getBaseUrl();
+  const token = getToken();
+
+  if (!baseUrl || !token || !docId) {
+    throw new Error('Missing chat configuration');
+  }
+
+  const url = `${baseUrl.replace(/\/+$/, '')}/${DOCUMENT_PATH}?docId=${docId}`;
+  const response = await fetch(url, {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to load chat document');
+  }
+
+  return await response.json();
 };


### PR DESCRIPTION
## Summary
- retrieve image data when loading chat messages
- add API call to fetch document bytes
- load document when tapping PDF attachment
- pass doc id to `openPdf`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_686f8c9f3bdc83219375f54a8b970ab1