### PR TITLE
Fix pdf loading via document GUID

### DIFF
--- a/cutesy-finance/components/ChatMessage.js
+++ b/cutesy-finance/components/ChatMessage.js
@@ -37,12 +37,13 @@ export default function ChatMessage({ item, previous, styles, setVideoUrl, setAu
       : item.message;
 
   const docType = parseInt(item.chatDocument?.supportingDocumentType, 10);
+  const docGuid = item.chatDocument?.guidId;
 
   let attachment = null;
-  if (item.chatDocumentId && item.chatDocumentId > 0 && !isNaN(docType)) {
+  if ((docGuid || (item.chatDocumentId && item.chatDocumentId > 0)) && !isNaN(docType)) {
     if (docType === 1) {
       attachment = (
-        <TouchableOpacity onPress={() => openPdf(item.chatDocumentId, item.chatDocument?.File)}>
+        <TouchableOpacity onPress={() => openPdf(docGuid || item.chatDocumentId, item.chatDocument?.File)}>
           <Ionicons
             name="document"
             size={48}

--- a/cutesy-finance/components/ChatScreen.js
+++ b/cutesy-finance/components/ChatScreen.js
@@ -80,11 +80,13 @@ export default function ChatScreen({ onLogout }) {
     WebBrowser.openBrowserAsync(url);
   };
 
-  const openPdf = async (docId, base64) => {
+  // Open a PDF document. If base64 content isn't already available,
+  // fetch it from the API using the document GUID.
+  const openPdf = async (docGuid, base64) => {
     let data = base64;
-    if (!data && docId) {
+    if (!data && docGuid) {
       try {
-        const doc = await getChatDocument(docId);
+        const doc = await getChatDocument(docGuid);
         data = doc.File || doc.file;
       } catch (e) {
         console.warn('Failed to load document', e);

--- a/cutesy-finance/services/ChatService.js
+++ b/cutesy-finance/services/ChatService.js
@@ -45,15 +45,16 @@ export const getChatMessages = async (pageNumber = 1) => {
   return data;
 };
 
-export const getChatDocument = async (docId) => {
+export const getChatDocument = async (docGuid) => {
   const baseUrl = getBaseUrl();
   const token = getToken();
 
-  if (!baseUrl || !token || !docId) {
+  if (!baseUrl || !token || !docGuid) {
     throw new Error('Missing chat configuration');
   }
 
-  const url = `${baseUrl.replace(/\/+$/, '')}/${DOCUMENT_PATH}?docId=${docId}`;
+  // Endpoint expects the chat document GUID string as the docId query parameter
+  const url = `${baseUrl.replace(/\/+$/, '')}/${DOCUMENT_PATH}?docId=${encodeURIComponent(docGuid)}`;
   const response = await fetch(url, {
     method: 'GET',
     headers: {


### PR DESCRIPTION
## Summary
- use chat document guid to fetch PDFs
- adjust ChatScreen and ChatMessage to pass guid value

## Testing
- `npm test` *(fails: Missing test script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_686f8fb4487c83218092a6051c393175