### PR TITLE
Change chat document retrieval to POST

### DIFF
--- a/cutesy-finance/services/ChatService.js
+++ b/cutesy-finance/services/ChatService.js
@@ -54,9 +54,9 @@ export const getChatDocument = async (docGuid) => {
   }
 
   // Endpoint expects the chat document GUID string as the docId query parameter
-  const url = `${baseUrl.replace(/\/+$/, '')}/${DOCUMENT_PATH}?docId=${encodeURIComponent(docGuid)}`;
+  const url = `${baseUrl.replace(/\/+$/, '')}/${DOCUMENT_PATH}?docId=${docGuid}`;
   const response = await fetch(url, {
-    method: 'GET',
+    method: 'POST',
     headers: {
       Authorization: `Bearer ${token}`,
     },


### PR DESCRIPTION
## Summary
- fetch chat document via POST request
- remove encoding of docId

## Testing
- `npm test --prefix cutesy-finance` *(fails: Missing script and network)*

------
https://chatgpt.com/codex/tasks/task_b_686f95e5737c832181dc778fc16eb610