### PR TITLE
Use GET for chat document fetch

### DIFF
--- a/cutesy-finance/services/ChatService.js
+++ b/cutesy-finance/services/ChatService.js
@@ -55,8 +55,9 @@ export const getChatDocument = async (docGuid) => {
 
   // Endpoint expects the chat document GUID string as the docId query parameter
   const url = `${baseUrl.replace(/\/+$/, '')}/${DOCUMENT_PATH}?docId=${docGuid}`;
+  // The document endpoint uses an HTTP GET
   const response = await fetch(url, {
-    method: 'POST',
+    method: 'GET',
     headers: {
       Authorization: `Bearer ${token}`,
     },


### PR DESCRIPTION
## Summary
- fix chat document API call to use GET

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686fc83e266c8321869d32e29f4f7cd5