### PR TITLE
Fix image preview loading in chat

### DIFF
--- a/cutesy-finance/components/ChatMessage.js
+++ b/cutesy-finance/components/ChatMessage.js
@@ -54,12 +54,16 @@ export default function ChatMessage({ item, previous, styles, setVideoUrl, setAu
       );
     } else if (docType === 2 || docType === 3) {
       const type = docType === 2 ? 'png' : 'jpeg';
-      const uri = `data:image/${type};base64,${item.chatDocument?.File}`;
-      attachment = (
-        <TouchableOpacity onPress={() => setImageUri(uri)}>
-          <Image source={{ uri }} style={styles.image} />
-        </TouchableOpacity>
-      );
+      const fileData = (item.chatDocument?.File || item.chatDocument?.file || '')
+        .replace(/\s/g, '');
+      if (fileData) {
+        const uri = `data:image/${type};base64,${fileData}`;
+        attachment = (
+          <TouchableOpacity onPress={() => setImageUri(uri)}>
+            <Image source={{ uri }} style={styles.image} />
+          </TouchableOpacity>
+        );
+      }
     }
   }
 

--- a/cutesy-finance/components/ChatScreen.js
+++ b/cutesy-finance/components/ChatScreen.js
@@ -94,6 +94,7 @@ export default function ChatScreen({ onLogout }) {
     }
 
     if (!data) return;
+    data = data.replace(/\s/g, '');
     const WebBrowser = await import('expo-web-browser');
     WebBrowser.openBrowserAsync(`data:application/pdf;base64,${data}`);
   };


### PR DESCRIPTION
## Summary
- clean up base64 data for chat document images
- trim whitespace when opening PDFs

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_686fcbddfd948321b8dce44e00c6ef8c