### PR TITLE
Fix duplicate message keys

### DIFF
--- a/cutesy-finance/components/ChatScreen.js
+++ b/cutesy-finance/components/ChatScreen.js
@@ -30,7 +30,14 @@ export default function ChatScreen({ onLogout }) {
     try {
       const data = await getChatMessages(p);
       const newMsgs = data && data.messages ? data.messages : [];
-      setMessages((prev) => (p === 1 ? newMsgs : [...prev, ...newMsgs]));
+      setMessages((prev) => {
+        if (p === 1) {
+          return newMsgs;
+        }
+        const existingIds = new Set(prev.map((m) => m.id));
+        const filtered = newMsgs.filter((m) => !existingIds.has(m.id));
+        return [...prev, ...filtered];
+      });
       setMore(data ? data.moreMessagesAvailable : false);
       setPage(p);
     } catch (e) {


### PR DESCRIPTION
## Summary
- avoid duplicate ChatMessage keys when loading more pages

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_b_686fec0329e88321a23ab94b647eded3