### PR TITLE
Improve media playback UI

### DIFF
--- a/cutesy-finance/components/ChatMessage.js
+++ b/cutesy-finance/components/ChatMessage.js
@@ -94,7 +94,13 @@ export default function ChatMessage({ item, previous, styles, setVideoUrl, setAu
       <Swipeable renderLeftActions={() => <View />} renderRightActions={() => <View /> }>
         <TouchableOpacity
           activeOpacity={0.8}
-          style={[styles.message, item.brokerSource ? styles.theirMessage : styles.myMessage]}
+          style={[
+            styles.message,
+            item.brokerSource ? styles.theirMessage : styles.myMessage,
+            !item.isVideo && !item.image && !item.isAudio && !attachment
+              ? { width: undefined, maxWidth: '70%' }
+              : null,
+          ]}
         >
           {item.isVideo && item.videoUrl ? (
             <TouchableOpacity onPress={() => setVideoUrl(item.videoUrl)} style={styles.videoContainer}>

--- a/cutesy-finance/components/ChatScreen.js
+++ b/cutesy-finance/components/ChatScreen.js
@@ -166,7 +166,15 @@ export default function ChatScreen({ onLogout }) {
           <TouchableOpacity style={styles.close} onPress={() => setVideoUrl(null)}>
             <Ionicons name="close" size={32} color="#fff" />
           </TouchableOpacity>
-          {videoUrl && <Video source={{ uri: videoUrl }} style={styles.media} useNativeControls resizeMode="contain" />}
+          {videoUrl && (
+            <Video
+              source={{ uri: videoUrl }}
+              style={styles.media}
+              useNativeControls
+              resizeMode="contain"
+              shouldPlay
+            />
+          )}
         </View>
       </Modal>
       <Modal visible={!!audioUrl} transparent onRequestClose={() => setAudioUrl(null)}>
@@ -265,7 +273,7 @@ const styles = StyleSheet.create({
   },
   modalBg: {
     flex: 1,
-    backgroundColor: 'rgba(0,0,0,0.8)',
+    backgroundColor: 'rgba(0,0,0,0.4)',
     justifyContent: 'center',
     alignItems: 'center',
   },


### PR DESCRIPTION
## Summary
- autoplay video messages when opened
- lighten chat modal overlay so media controls are visible
- shrink text-only chat bubbles

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68700f3defb083218000d1c7b71a4bc9