### PR TITLE
Add Azure pipeline and configure iOS bundle ID

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,40 @@
+trigger:
+- main
+
+pool:
+  vmImage: 'macOS-latest'
+
+variables:
+  APP_IDENTIFIER: 'com.dev.yavia.com'
+
+steps:
+- task: NodeTool@0
+  inputs:
+    versionSpec: '18.x'
+  displayName: 'Install Node.js'
+
+- script: |
+    npm install -g expo-cli eas-cli
+  displayName: 'Install Expo CLI'
+
+- script: |
+    cd cutesy-finance
+    npm ci
+  displayName: 'Install dependencies'
+
+- script: |
+    cd cutesy-finance
+    eas build --platform ios --non-interactive --profile production
+  env:
+    EXPO_TOKEN: $(EXPO_TOKEN)
+  displayName: 'Build iOS app'
+
+- script: |
+    cd cutesy-finance
+    eas submit --platform ios --non-interactive \
+      --latest \
+      --apple-id $(APPLE_ID) \
+      --asc-app-id $(ASC_APP_ID)
+  env:
+    EXPO_TOKEN: $(EXPO_TOKEN)
+  displayName: 'Submit to App Store'

--- a/cutesy-finance/app.json
+++ b/cutesy-finance/app.json
@@ -17,6 +17,7 @@
       "**/*"
     ],
     "ios": {
+      "bundleIdentifier": "com.dev.yavia.com",
       "supportsTablet": true
     },
     "android": {

--- a/cutesy-finance/eas.json
+++ b/cutesy-finance/eas.json
@@ -1,0 +1,16 @@
+{
+  "build": {
+    "production": {
+      "ios": {
+        "workflow": "managed",
+        "scheme": "release"
+      }
+    }
+  },
+  "submit": {
+    "production": {}
+  },
+  "cli": {
+    "version": ">= 1.0.0"
+  }
+}


### PR DESCRIPTION
## Summary
- configure iOS bundle identifier for Expo app
- add EAS build configuration
- add Azure DevOps pipeline that builds and submits the iOS app

## Testing
- `npm --version`
- `npm install` *(fails: registry access blocked)*

------
https://chatgpt.com/codex/tasks/task_b_6870c0ce530c83218faa5ec2d7a83184