### PR TITLE
Add local build credentials for DevOps pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -59,17 +59,39 @@ steps:
     npm install -g expo-cli eas-cli
   displayName: 'Install Expo CLI'
 
-- task: InstallAppleCertificate@2
+- task: DownloadSecureFile@1
+  name: iosCert
   inputs:
-    certSecureFile: 'CertificatesDistribIOS26.p12'
-    certPwd: '$(DistribIOS26)'
-    keychain: 'temp'
+    secureFile: 'CertificatesDistribIOS26.p12'
 
-- task: InstallAppleProvisioningProfile@1
-  displayName: Install Apple Provisioning Profile
+- task: DownloadSecureFile@1
+  name: iosProfile
   inputs:
-    provisioningProfileLocation: 'secureFiles'
-    provProfileSecureFile: 'dev_yavia_react_distrib_pp.mobileprovision'  
+    secureFile: 'dev_yavia_react_distrib_pp.mobileprovision'
+
+- script: |
+    security create-keychain -p "" build.keychain
+    security import $(iosCert.secureFilePath) -k build.keychain -P $(DistribIOS26) -T /usr/bin/codesign
+    security list-keychains -d user -s build.keychain
+    mkdir -p $HOME/Library/MobileDevice/Provisioning\ Profiles
+    cp $(iosProfile.secureFilePath) $HOME/Library/MobileDevice/Provisioning\ Profiles/
+  displayName: 'Install iOS credentials'
+
+- script: |
+    cd cutesy-finance
+    cat > credentials.json <<EOF
+    {
+      "ios": {
+        "provisioningProfilePath": "$(iosProfile.secureFilePath)",
+        "distributionCertificate": {
+          "path": "$(iosCert.secureFilePath)",
+          "password": "$(DistribIOS26)"
+        }
+      }
+    }
+    EOF
+  displayName: 'Create credentials.json'
+
 
 - script: |
     cd cutesy-finance

--- a/cutesy-finance/eas.json
+++ b/cutesy-finance/eas.json
@@ -1,7 +1,9 @@
 {
   "build": {
     "production": {
-      "ios": {}
+      "ios": {
+        "credentialsSource": "local"
+      }
     }
   },
   "submit": {


### PR DESCRIPTION
## Summary
- build iOS locally on DevOps by downloading the signing assets
- generate `credentials.json` at runtime so EAS CLI uses the provided certificate and provisioning profile
- configure EAS to load credentials from the local file

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_b_687123fd719883219a64eb4fa9622599