### PR TITLE
Update home screen icons

### DIFF
--- a/cutesy-finance/components/HomeScreen.js
+++ b/cutesy-finance/components/HomeScreen.js
@@ -37,10 +37,21 @@ export default function HomeScreen({ navigation, onLogout }) {
   };
 
   const actions = [
-    STRINGS.actionMortgage,
-    STRINGS.actionInsurance,
-    STRINGS.actionWealth,
-    STRINGS.actionGoal,
+    {
+      key: 'mortgage',
+      label: STRINGS.actionMortgage,
+      icon: require('../assets/circle-plus-solid.png'),
+    },
+    {
+      key: 'insurance',
+      label: STRINGS.actionInsurance,
+      icon: require('../assets/shield-halved-solid.png'),
+    },
+    {
+      key: 'wealth',
+      label: STRINGS.actionWealth,
+      icon: require("../assets/wallet-solid 1.png"),
+    },
   ];
 
   return (
@@ -74,13 +85,18 @@ export default function HomeScreen({ navigation, onLogout }) {
         <PrimaryButton style={styles.profileBtn}>{STRINGS.profileCta}</PrimaryButton>
       </View>
 
-      <ScrollView horizontal showsHorizontalScrollIndicator={false} style={styles.actionScroll} contentContainerStyle={styles.actionContent}>
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        style={styles.actionScroll}
+        contentContainerStyle={styles.actionContent}
+      >
         {actions.map((a) => (
-          <View key={a} style={styles.actionPanel}>
+          <View key={a.key} style={styles.actionPanel}>
             <View style={styles.actionIconContainer}>
-              <Ionicons name="add" size={14} color={COLORS.white} />
+              <Image source={a.icon} style={styles.actionIcon} />
             </View>
-            <Text style={styles.actionText}>{a}</Text>
+            <Text style={styles.actionText}>{a.label}</Text>
           </View>
         ))}
       </ScrollView>
@@ -236,6 +252,12 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
     marginRight: 6,
+  },
+  actionIcon: {
+    width: 14,
+    height: 14,
+    resizeMode: 'contain',
+    tintColor: COLORS.black,
   },
   actionText: {
     fontFamily: 'Poppins_400Regular',

--- a/cutesy-finance/components/strings.js
+++ b/cutesy-finance/components/strings.js
@@ -8,7 +8,6 @@ export const STRINGS = {
   actionMortgage: 'Add Mortgage',
   actionInsurance: 'Add Insurance',
   actionWealth: 'Add Wealth',
-  actionGoal: 'Add Goal',
   exploreText: 'Explore your product options from Insurance to Wealth.',
   exploreButton: 'Explore Now',
   myProducts: 'My Products',


### PR DESCRIPTION
## Summary
- tweak home screen action pane icons to use images
- remove "Add Goal" from home screen and strings

## Testing
- `npm test --prefix cutesy-finance` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68726095f2cc8321874aa5a335d4032b