### PR TITLE
Align header titles next to burger

### DIFF
--- a/cutesy-finance/components/ChatScreen.js
+++ b/cutesy-finance/components/ChatScreen.js
@@ -230,11 +230,11 @@ const styles = StyleSheet.create({
     zIndex: 1,
   },
   header: {
-    fontSize: 18,
+    fontSize: 16,
     fontFamily: 'Poppins_400Regular',
-    color: COLORS.primary,
+    color: COLORS.black,
     marginBottom: 10,
-    marginLeft: 60,
+    marginLeft: 50,
     marginTop: 5,
   },
   scroll: {

--- a/cutesy-finance/components/DocuvaultScreen.js
+++ b/cutesy-finance/components/DocuvaultScreen.js
@@ -174,10 +174,13 @@ const styles = StyleSheet.create({
     zIndex: 1,
   },
   header: {
-    fontSize: 18,
+    fontSize: 16,
     fontFamily: 'Poppins_400Regular',
-    color: '#cebffa',
+    color: COLORS.black,
     marginBottom: 10,
+    marginLeft: 50,
+    alignSelf: 'flex-start',
+    marginTop: 5,
   },
   summaryBox: {
     width: '90%',

--- a/cutesy-finance/components/HomeScreen.js
+++ b/cutesy-finance/components/HomeScreen.js
@@ -149,11 +149,13 @@ const styles = StyleSheet.create({
     zIndex: 1,
   },
   header: {
-    fontSize: 18,
+    fontSize: 16,
     fontFamily: 'Poppins_400Regular',
-    color: COLORS.primary,
+    color: COLORS.black,
     marginTop: 10,
     marginBottom: 10,
+    marginLeft: 50,
+    alignSelf: 'flex-start',
   },
   budgetBox: {
     flexDirection: 'row',

--- a/cutesy-finance/components/ProductsScreen.js
+++ b/cutesy-finance/components/ProductsScreen.js
@@ -174,11 +174,13 @@ const styles = StyleSheet.create({
     zIndex: 1,
   },
   header: {
-    fontSize: 18,
+    fontSize: 16,
     fontFamily: 'Poppins_400Regular',
-    color: COLORS.primary,
+    color: COLORS.black,
     marginTop: 10,
     marginBottom: 10,
+    marginLeft: 50,
+    alignSelf: 'flex-start',
   },
   panel: {
     width: '90%',


### PR DESCRIPTION
## Summary
- adjust header positioning and size across screens
- match ChatScreen header style to others

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68726837999083219c42a27fe878469b