### PR TITLE
Fix insurance screen layout and menu navigation

### DIFF
--- a/cutesy-finance/components/ChatScreen.js
+++ b/cutesy-finance/components/ChatScreen.js
@@ -160,7 +160,12 @@ export default function ChatScreen({ onLogout }) {
           <Ionicons name="paper-plane" size={20} color="#fff" />
         </TouchableOpacity>
       </View>
-      <DrawerMenu visible={menuVisible} onClose={() => setMenuVisible(false)} onLogout={onLogout} />
+      <DrawerMenu
+        visible={menuVisible}
+        onClose={() => setMenuVisible(false)}
+        onLogout={onLogout}
+        onHome={() => navigation.navigate('Chat')}
+      />
       <Modal visible={!!videoUrl} transparent onRequestClose={() => setVideoUrl(null)}>
         <View style={styles.modalBg}>
           <TouchableOpacity style={styles.close} onPress={() => setVideoUrl(null)}>

--- a/cutesy-finance/components/Dashboard.js
+++ b/cutesy-finance/components/Dashboard.js
@@ -103,7 +103,12 @@ export default function Dashboard({ onLogout }) {
         <DetailModal onClose={() => setDetailVisible(false)} />
       </Modal>
       {/* Burger drawer menu */}
-      <DrawerMenu visible={menuVisible} onClose={() => setMenuVisible(false)} onLogout={onLogout} />
+      <DrawerMenu
+        visible={menuVisible}
+        onClose={() => setMenuVisible(false)}
+        onLogout={onLogout}
+        onHome={() => navigation.navigate('Home')}
+      />
     </Animated.View>
   );
 }

--- a/cutesy-finance/components/DocuvaultScreen.js
+++ b/cutesy-finance/components/DocuvaultScreen.js
@@ -154,6 +154,7 @@ export default function DocuvaultScreen({ onLogout }) {
         visible={menuVisible}
         onClose={() => setMenuVisible(false)}
         onLogout={onLogout}
+        onHome={() => navigation.navigate('Docuvault')}
       />
     </Animated.View>
   );

--- a/cutesy-finance/components/DrawerMenu.js
+++ b/cutesy-finance/components/DrawerMenu.js
@@ -4,7 +4,11 @@ import React from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, Modal } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 
-export default function DrawerMenu({ visible, onClose, onLogout }) {
+export default function DrawerMenu({ visible, onClose, onLogout, onHome }) {
+  const handleHome = () => {
+    onClose && onClose();
+    if (onHome) onHome();
+  };
   const options = [
     { label: 'Option A', icon: 'star' },
     { label: 'Option B', icon: 'planet' },
@@ -25,7 +29,7 @@ export default function DrawerMenu({ visible, onClose, onLogout }) {
       <View style={StyleSheet.absoluteFill} pointerEvents="box-none">
         <TouchableOpacity style={styles.backdrop} onPress={onClose} />
         <View style={styles.menu} pointerEvents="auto">
-          <TouchableOpacity onPress={onClose} style={[styles.itemRow, styles.homeButton]}>
+          <TouchableOpacity onPress={handleHome} style={[styles.itemRow, styles.homeButton]}>
             <Ionicons name="home" size={20} color="#fff" style={styles.itemIcon} />
             <Text style={styles.item}>Home</Text>
           </TouchableOpacity>

--- a/cutesy-finance/components/HomeScreen.js
+++ b/cutesy-finance/components/HomeScreen.js
@@ -127,7 +127,12 @@ export default function HomeScreen({ navigation, onLogout }) {
         </View>
       </View>
 
-        <DrawerMenu visible={menuVisible} onClose={() => setMenuVisible(false)} onLogout={onLogout} />
+        <DrawerMenu
+          visible={menuVisible}
+          onClose={() => setMenuVisible(false)}
+          onLogout={onLogout}
+          onHome={() => navigation.navigate('Home')}
+        />
       </ScrollView>
     </Animated.View>
   );

--- a/cutesy-finance/components/InsuranceListScreen.js
+++ b/cutesy-finance/components/InsuranceListScreen.js
@@ -8,17 +8,18 @@ import {
   Image,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
-import DrawerMenu from './DrawerMenu';
-import { COLORS } from './Theme';
+import { COLORS, withOpacity } from './Theme';
 import { getInsurance } from '../services/InsuranceService';
 import { InsuranceEnum } from '../enums';
 import { getEnumKeyByValue } from '../utils/enumUtils';
 
-export default function InsuranceListScreen({ navigation }) {
-  const [insurances, setInsurances] = useState([]);
-  const [menuVisible, setMenuVisible] = useState(false);
+export default function InsuranceListScreen({ navigation, route }) {
+  const [insurances, setInsurances] = useState(
+    Array.isArray(route?.params?.insurances) ? route.params.insurances : []
+  );
 
   useEffect(() => {
+    if (insurances.length > 0) return;
     const load = async () => {
       try {
         const data = await getInsurance();
@@ -30,7 +31,7 @@ export default function InsuranceListScreen({ navigation }) {
       }
     };
     load();
-  }, []);
+  }, [insurances]);
 
   const renderRow = (label, value, icon, index, last = false) => (
     <View key={index}>
@@ -67,14 +68,15 @@ export default function InsuranceListScreen({ navigation }) {
 
   return (
     <View style={styles.container}>
-      <TouchableOpacity onPress={() => setMenuVisible(true)} style={styles.burger}>
-        <Ionicons name="menu" size={24} color={COLORS.textDark} />
-      </TouchableOpacity>
       <TouchableOpacity onPress={() => navigation.goBack()} style={styles.back}>
-        <Ionicons name="chevron-back" size={24} color={COLORS.textDark} />
+        <Ionicons
+          name="chevron-back"
+          size={24}
+          color={withOpacity(COLORS.primary, 0.6)}
+        />
       </TouchableOpacity>
       <ScrollView contentContainerStyle={styles.content}>
-        <Text style={styles.header}>My Insurance</Text>
+        <Text style={styles.header}>Insurance</Text>
         {insurances.map((ins, idx) => {
           const startDate = new Date(ins.startDate || ins.StartDate || 0);
           const endDate = new Date(ins.endDate || ins.EndDate || 0);
@@ -159,7 +161,6 @@ export default function InsuranceListScreen({ navigation }) {
           );
         })}
       </ScrollView>
-      <DrawerMenu visible={menuVisible} onClose={() => setMenuVisible(false)} />
     </View>
   );
 }
@@ -174,18 +175,13 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     paddingBottom: 40,
   },
-  burger: {
+  back: {
     position: 'absolute',
     left: 10,
     top: 40,
-    padding: 4,
-    zIndex: 1,
-  },
-  back: {
-    position: 'absolute',
-    left: 50,
-    top: 40,
-    padding: 4,
+    padding: 6,
+    borderRadius: 20,
+    backgroundColor: withOpacity(COLORS.primary, 0.2),
     zIndex: 1,
   },
   header: {
@@ -193,9 +189,8 @@ const styles = StyleSheet.create({
     fontFamily: 'Poppins_400Regular',
     color: COLORS.black,
     marginBottom: 10,
-    marginLeft: 50,
     marginTop: 5,
-    alignSelf: 'flex-start',
+    alignSelf: 'center',
   },
   panel: {
     width: '90%',

--- a/cutesy-finance/components/ProductsScreen.js
+++ b/cutesy-finance/components/ProductsScreen.js
@@ -109,7 +109,9 @@ export default function ProductsScreen({ navigation, onLogout }) {
               key={p.key}
               style={[styles.panel, { backgroundColor: p.color }]}
               activeOpacity={0.8}
-              onPress={() => navigation.navigate('InsuranceList')}
+              onPress={() =>
+                navigation.navigate('InsuranceList', { insurances })
+              }
             >
               <Text style={styles.panelHeader}>{p.title}</Text>
               <View style={styles.folderLayerTwo} />
@@ -160,6 +162,7 @@ export default function ProductsScreen({ navigation, onLogout }) {
           visible={menuVisible}
           onClose={() => setMenuVisible(false)}
           onLogout={onLogout}
+          onHome={() => navigation.navigate('Products')}
         />
       </ScrollView>
     </Animated.View>


### PR DESCRIPTION
## Summary
- update `DrawerMenu` so the Home button navigates to the root screen
- center Insurance screen title and replace burger with back button
- pass fetched insurances from Products screen
- wire menu Home buttons on all screens

## Testing
- `npm -s run lint` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68727053b3f08321887ab5e036f700e0