### PR TITLE
Add Document Vault Type fetch and info display

### DIFF
--- a/cutesy-finance/services/DocumentVaultTypeService.js
+++ b/cutesy-finance/services/DocumentVaultTypeService.js
@@ -1,0 +1,28 @@
+import { getBaseUrl, getToken } from './LoginService';
+import * as SecureStore from 'expo-secure-store';
+
+const VAULT_TYPE_PATH = 'documentvaulttype';
+
+export const getDocumentVaultTypes = async () => {
+  const baseUrl = getBaseUrl();
+  const token = getToken();
+  const masterBrokerId = await SecureStore.getItemAsync('masterBrokerId');
+
+  if (!baseUrl || !token || !masterBrokerId) {
+    throw new Error('Missing document vault type configuration');
+  }
+
+  const url = `${baseUrl.replace(/\/+$/, '')}/${VAULT_TYPE_PATH}?brokerId=${masterBrokerId}`;
+  const response = await fetch(url, {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to load document vault types');
+  }
+
+  return await response.json();
+};


### PR DESCRIPTION
## Summary
- fetch document vault type list using new DocumentVaultTypeService
- show document names and info toggle on Docuvault screen

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6872798573ec832190a3bd24ee9ae337