### PR TITLE
Update document service descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,16 @@ The app uses the **Poppins** font via `@expo-google-fonts/poppins`, so the first
 - Dashboard with panels, bottom tabs, burger menu and logout
 
 Everything is heavily commented in the code for learning purposes.
+
+## Services
+
+The app talks to a backend API using a few small service modules. Two of the
+services relate specifically to the document vault feature:
+
+- **DocumentsRequirementService** – fetches the list of document requirements
+  that the user still needs to provide. Each requirement record references a
+  DocuVault type.
+- **DocumentVaultTypeService** – returns metadata for each DocuVault type (name
+  and additional details). The DocuVault type information can be cross-matched
+  with the requirements from `DocumentsRequirementService` to display the
+  correct descriptions on the uploads page.

--- a/cutesy-finance/services/DocumentVaultTypeService.js
+++ b/cutesy-finance/services/DocumentVaultTypeService.js
@@ -1,6 +1,10 @@
 import { getBaseUrl, getToken } from './LoginService';
 import * as SecureStore from 'expo-secure-store';
 
+// Provides metadata about available DocuVault types. The returned information
+// (name, prompts, etc.) can be used to enrich the requirements loaded via
+// DocumentsRequirementService.
+
 const VAULT_TYPE_PATH = 'documentvaulttype';
 
 export const getDocumentVaultTypes = async () => {

--- a/cutesy-finance/services/DocumentsRequirementService.js
+++ b/cutesy-finance/services/DocumentsRequirementService.js
@@ -1,6 +1,10 @@
 import { getBaseUrl, getToken } from './LoginService';
 import * as SecureStore from 'expo-secure-store';
 
+// Retrieves the list of document requirements that the currently logged in user
+// still needs to supply. Each requirement includes a DocuVault type identifier
+// which can be matched with the metadata returned by DocumentVaultTypeService.
+
 const REQUIRED_PATH = 'DocumentsRequirement/requireddocuments';
 
 export const getRequiredDocuments = async () => {


### PR DESCRIPTION
## Summary
- document the difference between document services
- clarify service roles with comments

## Testing
- `node -v`
- `npm -v`


------
https://chatgpt.com/codex/tasks/task_b_68727f3d20d4832190f44e1e9aba3047